### PR TITLE
Add track parameters to control target throughput and clients for search operations

### DIFF
--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -58,147 +58,339 @@
         {
           "operation": "index-stats",
           "warmup-iterations": 500,
-          "iterations": 1000,
-          "target-throughput": 90
+          "iterations": 1000
+          {%- if not target_throughput %}
+          ,"target-throughput": 90
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "node-stats",
           "warmup-iterations": 100,
-          "iterations": 1000,
-          "target-throughput": 90
+          "iterations": 1000
+          {%- if not target_throughput %}
+          ,"target-throughput": 90
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "default",
           "warmup-iterations": 500,
-          "iterations": 1000,
-          "target-throughput": 50
+          "iterations": 1000
+          {%- if not target_throughput %}
+          ,"target-throughput": 50
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "term",
           "warmup-iterations": 500,
-          "iterations": 1000,
-          "target-throughput": 140
+          "iterations": 1000
+          {%- if not target_throughput %}
+          ,"target-throughput": 140
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "phrase",
           "warmup-iterations": 500,
-          "iterations": 1000,
-          "target-throughput": 140
+          "iterations": 1000
+          {%- if not target_throughput %}
+          ,"target-throughput": 140
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "country_agg_uncached",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 3.6
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 3.6
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "country_agg_cached",
           "warmup-iterations": 1000,
-          "iterations": 1000,
-          "target-throughput": 100
+          "iterations": 1000
+          {%- if not target_throughput %}
+          ,"target-throughput": 100
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "scroll",
           "warmup-iterations": 200,
           "iterations": 100,
-          "#COMMENT": "Throughput is considered per request. So we issue one scroll request per second which will retrieve 25 pages",
-          "target-throughput": 0.8
+          "#COMMENT": "Throughput is considered per request. So we issue one scroll request per second which will retrieve 25 pages"
+          {%- if not target_throughput %}
+          ,"target-throughput": 0.8
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "expression",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 2
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 2
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "painless_static",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 1.5
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1.5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "painless_dynamic",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 1.5
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1.5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "decay_geo_gauss_function_score",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 1
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "decay_geo_gauss_script_score",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 1
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "field_value_function_score",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 1.5
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1.5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "field_value_script_score",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 1.5
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1.5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "random_function_score",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 1.5
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1.5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "random_script_score",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 1.5
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1.5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "large_terms",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 1.1
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1.1
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "large_filtered_terms",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 1.1
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1.1
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "large_prohibited_terms",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 1.1
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1.1
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "desc_sort_population",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 1.5
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1.5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "asc_sort_population",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 1.5
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1.5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "desc_sort_geonameid",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 6
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 6
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "asc_sort_geonameid",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 6
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 6
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         }
       ]
     },

--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -60,26 +60,58 @@
         {
           "operation": "polygon",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 2
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 2
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "bbox",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 2
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 2
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "distance",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 5
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "distanceRange",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 0.5
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 0.5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         }
       ]
     },

--- a/geopointshape/challenges/default.json
+++ b/geopointshape/challenges/default.json
@@ -58,14 +58,30 @@
         {
           "operation": "polygon",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 2
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 2
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "bbox",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 2
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 2
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         }
       ]
     },

--- a/geoshape/challenges/default.json
+++ b/geoshape/challenges/default.json
@@ -123,14 +123,30 @@
         {
           "operation": "polygon",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 0.3
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 0.3
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "bbox",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 0.25
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 0.25
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         }
       ]
     }

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -58,45 +58,101 @@
         {
           "operation": "default",
           "warmup-iterations": 500,
-          "iterations": 100,
-          "target-throughput": 8
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 8
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "term",
           "warmup-iterations": 500,
-          "iterations": 100,
-          "target-throughput": 50
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 50
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "range",
           "warmup-iterations": 100,
-          "iterations": 100,
-          "target-throughput": 1
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "hourly_agg",
           "warmup-iterations": 100,
-          "iterations": 100,
-          "target-throughput": 0.2
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 0.2
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "scroll",
           "warmup-iterations": 100,
           "iterations": 200,
-          "#COMMENT": "Throughput is considered per request. So we issue one scroll request per second which will retrieve 25 pages",
-          "target-throughput": 1
+          "#COMMENT": "Throughput is considered per request. So we issue one scroll request per second which will retrieve 25 pages"
+          {%- if not target_throughput %}
+          ,"target-throughput": 1
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "desc_sort_timestamp",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 0.5
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 0.5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "asc_sort_timestamp",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 0.5
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 0.5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "name": "force-merge-1-seg",
@@ -127,15 +183,31 @@
           "name": "desc-sort-timestamp-after-force-merge-1-seg",
           "operation": "desc_sort_timestamp",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 2
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 2
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "name": "asc-sort-timestamp-after-force-merge-1-seg",
           "operation": "asc_sort_timestamp",
           "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 2
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 2
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         }
       ]
     },

--- a/metricbeat/challenges/default.json
+++ b/metricbeat/challenges/default.json
@@ -58,26 +58,58 @@
         {
           "operation": "auto-date-histogram",
           "warmup-iterations": 50,
-          "iterations": 100,
-          "target-throughput": 2
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 2
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "auto-date-histogram-with-tz",
           "warmup-iterations": 50,
-          "iterations": 100,
-          "target-throughput": 2
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 2
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "date-histogram",
           "warmup-iterations": 50,
-          "iterations": 100,
-          "target-throughput": 2
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 2
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "date-histogram-with-tz",
           "warmup-iterations": 50,
-          "iterations": 100,
-          "target-throughput": 2
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 2
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         }
       ]
     }

--- a/nested/challenges/default.json
+++ b/nested/challenges/default.json
@@ -58,52 +58,115 @@
         },
         {
           "operation": "randomized-nested-queries",
-          "clients": 2,
-          "target-throughput": 20,
           "warmup-iterations": 500,
           "iterations": 1000
+          {%- if not target_throughput %}
+          ,"target-throughput": 20
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 2
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "randomized-term-queries",
-          "clients": 2,
-          "target-throughput": 25,
           "warmup-iterations": 500,
           "iterations": 200
+          {%- if not target_throughput %}
+          ,"target-throughput": 25
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 2
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "randomized-sorted-term-queries",
-          "clients": 2,
           "warmup-iterations": 500,
-          "target-throughput": 16,
           "iterations": 200
+          {%- if not target_throughput %}
+          ,"target-throughput": 16
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 2
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "match-all",
-          "clients": 2,
-          "target-throughput": 5,
           "warmup-iterations": 500,
           "iterations": 200
+          {%- if not target_throughput %}
+          ,"target-throughput": 5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 2
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "nested-date-histo",
-          "clients": 2,
-          "target-throughput": 1,
           "warmup-iterations": 100,
           "iterations": 200
+          {%- if not target_throughput %}
+          ,"target-throughput": 1
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 2
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "randomized-nested-queries-with-inner-hits_default",
-          "clients": 2,
-          "target-throughput": 18,
           "warmup-iterations": 500,
           "iterations": 1000
+          {%- if not target_throughput %}
+          ,"target-throughput": 18
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 2
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "randomized-nested-queries-with-inner-hits_default_big_size",
-          "clients": 2,
-          "target-throughput": 16,
           "warmup-iterations": 500,
           "iterations": 1000
+          {%- if not target_throughput %}
+          ,"target-throughput": 16
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 2
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         }
       ]
     },

--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -59,50 +59,114 @@
         {
           "operation": "range_field_big_range",
           "warmup-iterations": 100,
-          "iterations": 500,
-          "target-throughput": 8
+          "iterations": 500
+          {%- if not target_throughput %}
+          ,"target-throughput": 8
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "range_field_small_range",
           "warmup-iterations": 100,
-          "iterations": 500,
-          "target-throughput": 10
+          "iterations": 500
+          {%- if not target_throughput %}
+          ,"target-throughput": 10
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "range_field_conjunction_big_range_small_term_query",
           "warmup-iterations": 100,
-          "iterations": 500,
-          "target-throughput": 10
+          "iterations": 500
+          {%- if not target_throughput %}
+          ,"target-throughput": 10
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "range_field_conjunction_small_range_small_term_query",
           "warmup-iterations": 100,
-          "iterations": 500,
-          "target-throughput": 10
+          "iterations": 500
+          {%- if not target_throughput %}
+          ,"target-throughput": 10
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "range_field_conjunction_small_range_big_term_query",
           "warmup-iterations": 100,
-          "iterations": 500,
-          "target-throughput": 4
+          "iterations": 500
+          {%- if not target_throughput %}
+          ,"target-throughput": 4
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "range_field_conjunction_big_range_big_term_query",
           "warmup-iterations": 100,
-          "iterations": 500,
-          "target-throughput": 1
+          "iterations": 500
+          {%- if not target_throughput %}
+          ,"target-throughput": 1
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "range_field_disjunction_small_range_small_term_query",
           "warmup-iterations": 100,
-          "iterations": 500,
-          "target-throughput": 10
+          "iterations": 500
+          {%- if not target_throughput %}
+          ,"target-throughput": 10
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "range_field_disjunction_big_range_small_term_query",
           "warmup-iterations": 100,
-          "iterations": 500,
-          "target-throughput": 6
+          "iterations": 500
+          {%- if not target_throughput %}
+          ,"target-throughput": 6
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         }
       ]
     },
@@ -212,129 +276,291 @@
         },
         {
           "operation": "max_temp",
-          "clients": 1,
           "warmup-iterations": 10,
-          "iterations": 100,
-          "target-throughput": 4
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 4
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 1
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "last_max_temp_top_hits",
-          "clients": 1,
           "warmup-iterations": 10,
-          "iterations": 100,
-          "target-throughput": 4
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 4
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 1
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "last_max_temp_top_metrics",
-          "clients": 1,
           "warmup-iterations": 10,
-          "iterations": 100,
-          "target-throughput": 4
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 4
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 1
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "max_temp_per_station_10",
-          "clients": 1,
           "warmup-iterations": 10,
-          "iterations": 100,
-          "target-throughput": 2
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 2
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 1
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "last_max_temp_per_station_top_hits_10",
-          "clients": 1,
           "warmup-iterations": 10,
-          "iterations": 100,
-          "target-throughput": 2
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 2
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 1
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "last_max_temp_per_station_top_metrics_10",
-          "clients": 1,
           "warmup-iterations": 10,
-          "iterations": 100,
-          "target-throughput": 2
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 2
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 1
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "last_min_and_max_temp_per_station_top_metrics_10",
-          "clients": 1,
           "warmup-iterations": 10,
-          "iterations": 100,
-          "target-throughput": 2
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 2
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 1
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "last_five_max_temp_per_station_top_metrics_10",
-          "clients": 1,
           "warmup-iterations": 10,
-          "iterations": 100,
-          "target-throughput": 2
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 2
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 1
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "max_temp_per_station_10_depth_first",
-          "clients": 1,
           "warmup-iterations": 10,
-          "iterations": 100,
-          "target-throughput": 2
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 2
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 1
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "last_max_temp_per_station_top_hits_10_depth_first",
-          "clients": 1,
           "warmup-iterations": 10,
-          "iterations": 100,
-          "target-throughput": 1
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 1
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "last_max_temp_per_station_top_metrics_10_depth_first",
-          "clients": 1,
           "warmup-iterations": 10,
-          "iterations": 100,
-          "target-throughput": 1
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 1
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "last_max_temp_per_station_top_metrics_10_sort_by",
-          "clients": 1,
           "warmup-iterations": 10,
-          "iterations": 100,
-          "target-throughput": 1
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 1
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "max_temp_per_station_5000",
-          "clients": 1,
           "warmup-iterations": 10,
-          "iterations": 100,
-          "target-throughput": 1
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 1
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "last_max_temp_per_station_top_hits_5000",
-          "clients": 1,
           "warmup-iterations": 10,
-          "iterations": 50,
-          "target-throughput": 1
+          "iterations": 50
+          {%- if not target_throughput %}
+          ,"target-throughput": 1
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 1
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "last_max_temp_per_station_top_hits_5000_via_source",
-          "clients": 1,
           "warmup-iterations": 10,
-          "iterations": 50,
-          "target-throughput": 1
+          "iterations": 50
+          {%- if not target_throughput %}
+          ,"target-throughput": 1
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 1
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "last_max_temp_per_station_top_metrics_5000",
-          "clients": 1,
           "warmup-iterations": 10,
-          "iterations": 50,
-          "target-throughput": 1
+          "iterations": 50
+          {%- if not target_throughput %}
+          ,"target-throughput": 1
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 1
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "last_min_and_max_temp_per_station_top_metrics_5000",
-          "clients": 1,
           "warmup-iterations": 10,
-          "iterations": 50,
-          "target-throughput": 1
+          "iterations": 50
+          {%- if not target_throughput %}
+          ,"target-throughput": 1
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 1
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "last_five_max_temp_per_station_top_metrics_5000",
-          "clients": 1,
           "warmup-iterations": 10,
-          "iterations": 50,
-          "target-throughput": 1
+          "iterations": 50
+          {%- if not target_throughput %}
+          ,"target-throughput": 1
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if not search_clients %}
+          ,"clients": 1
+          {%- elif search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         }
       ]
     },

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -54,32 +54,72 @@
         {
           "operation": "default",
           "warmup-iterations": 50,
-          "iterations": 100,
-          "target-throughput": 3
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 3
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "range",
           "warmup-iterations": 50,
-          "iterations": 100,
-          "target-throughput": 0.7
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 0.7
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "distance_amount_agg",
           "warmup-iterations": 50,
-          "iterations": 100,
-          "target-throughput": 2
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 2
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "autohisto_agg",
           "warmup-iterations": 50,
-          "iterations": 100,
-          "target-throughput": 1.5
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1.5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "date_histogram_agg",
           "warmup-iterations": 50,
-          "iterations": 100,
-          "target-throughput": 1.5
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1.5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         }
       ]
     },

--- a/percolator/challenges/default.json
+++ b/percolator/challenges/default.json
@@ -59,38 +59,86 @@
         {
           "operation": "percolator_with_content_president_bush",
           "warmup-iterations": 100,
-          "iterations": 100,
-          "target-throughput": 50
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 50
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "percolator_with_content_saddam_hussein",
           "warmup-iterations": 100,
-          "iterations": 100,
-          "target-throughput": 50
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 50
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "percolator_with_content_hurricane_katrina",
           "warmup-iterations": 100,
-          "iterations": 100,
-          "target-throughput": 50
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 50
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "percolator_with_content_google",
           "warmup-iterations": 100,
-          "iterations": 100,
-          "target-throughput": 30
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 30
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "percolator_no_score_with_content_google",
           "warmup-iterations": 100,
-          "iterations": 100,
-          "target-throughput": 100
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 100
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "percolator_with_highlighting",
           "warmup-iterations": 100,
-          "iterations": 100,
-          "target-throughput": 50
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 50
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "percolator_with_content_ignore_me",
@@ -102,8 +150,16 @@
         {
           "operation": "percolator_no_score_with_content_ignore_me",
           "warmup-iterations": 100,
-          "iterations": 100,
-          "target-throughput": 15
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 15
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         }
       ]
     }

--- a/pmc/challenges/default.json
+++ b/pmc/challenges/default.json
@@ -68,38 +68,86 @@
         {
           "operation": "default",
           "warmup-iterations": 500,
-          "iterations": 200,
-          "target-throughput": 20
+          "iterations": 200
+          {%- if not target_throughput %}
+          ,"target-throughput": 20
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "term",
           "warmup-iterations": 500,
-          "iterations": 200,
-          "target-throughput": 20
+          "iterations": 200
+          {%- if not target_throughput %}
+          ,"target-throughput": 20
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "phrase",
           "warmup-iterations": 500,
-          "iterations": 200,
-          "target-throughput": 20
+          "iterations": 200
+          {%- if not target_throughput %}
+          ,"target-throughput": 20
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "articles_monthly_agg_uncached",
           "warmup-iterations": 500,
-          "iterations": 200,
-          "target-throughput": 20
+          "iterations": 200
+          {%- if not target_throughput %}
+          ,"target-throughput": 20
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "articles_monthly_agg_cached",
           "warmup-iterations": 500,
-          "iterations": 200,
-          "target-throughput": 20
+          "iterations": 200
+          {%- if not target_throughput %}
+          ,"target-throughput": 20
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "scroll",
           "warmup-iterations": 50,
-          "iterations": 100,
-          "target-throughput": 0.5
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 0.5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%- if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         }
       ]
     },


### PR DESCRIPTION
**Background**
This change adds target_throughput and search_clients as track parameters for all search operations where a default target throughput is specified. If no user-specified value for these new parameters exists, then the existing defaults will be used. Otherwise, the user-specified value will be honored. There is a special case for target-throughput where 'none' as a string can be specified to remove the target-throughput setting.

This change will allow our runs to be more configurable and is a step in the direction of automated saturation testing.

Additionally, it will allow us to remove target throughput on our daily benchmarks to get more significant query performance numbers.

**Testing**
I spun up the beta AMI and switched the tracks remote to my repo and pulled all branches. The I tested the following:

1. Ran all challenges for all tracks for all branches (except master) in test mode with no track-params specified.

The only failures were in eventdata (which this PR doesn't touch) when running the transform challenge, and the expected failures of 'challenge does not exist' or 'track does not exist' for lower distribution versions.

2. Repeated 1 with `search_clients:2,target_throughput:'none'` as track-params

I did not run eventdata for step 2 as it's unchanged by this PR. There were no new failures except for SO, which threw an error saying the params were unsupported, which is the expected behavior.